### PR TITLE
Add optional CloudWatch logging support

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,6 +1,79 @@
 import logging
 import os
-import os.path as _p
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+class CloudWatchLogsHandler(logging.Handler):
+    """Minimal CloudWatch Logs handler using boto3."""
+
+    def __init__(
+        self,
+        *,
+        log_group: str,
+        log_stream: str,
+        region_name: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        session = boto3.Session()
+        self.client = session.client("logs", region_name=region_name)
+        self.log_group = log_group
+        self.log_stream = log_stream
+        self.sequence_token: Optional[str] = None
+        self._ensure_resources()
+
+    def _ensure_resources(self) -> None:
+        try:
+            self.client.create_log_group(logGroupName=self.log_group)
+        except ClientError as exc:  # pragma: no cover - benign race
+            error_code = exc.response.get("Error", {}).get("Code")
+            if error_code not in {"ResourceAlreadyExistsException", "ResourceAlreadyExists"}:
+                raise
+
+        try:
+            self.client.create_log_stream(
+                logGroupName=self.log_group,
+                logStreamName=self.log_stream,
+            )
+        except ClientError as exc:  # pragma: no cover - benign race
+            error_code = exc.response.get("Error", {}).get("Code")
+            if error_code not in {"ResourceAlreadyExistsException", "ResourceAlreadyExists"}:
+                raise
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - network interaction
+        message = self.format(record)
+        timestamp = int(record.created * 1000)
+        event = {"timestamp": timestamp, "message": message}
+        put_kwargs = {
+            "logGroupName": self.log_group,
+            "logStreamName": self.log_stream,
+            "logEvents": [event],
+        }
+        if self.sequence_token is not None:
+            put_kwargs["sequenceToken"] = self.sequence_token
+
+        try:
+            response = self.client.put_log_events(**put_kwargs)
+        except ClientError as exc:
+            error = exc.response.get("Error", {})
+            code = error.get("Code")
+            if code in {"InvalidSequenceTokenException", "DataAlreadyAcceptedException"}:
+                self.sequence_token = (
+                    exc.response.get("expectedSequenceToken")
+                    or error.get("expectedSequenceToken")
+                    or error.get("message", "").rsplit(" ", 1)[-1]
+                )
+                if self.sequence_token:
+                    put_kwargs["sequenceToken"] = self.sequence_token
+                    response = self.client.put_log_events(**put_kwargs)
+                else:
+                    raise
+            else:
+                raise
+
+        self.sequence_token = response.get("nextSequenceToken")
 
 
 def setup_logging():
@@ -29,7 +102,25 @@ def setup_logging():
         level=level,
         format="%(asctime)s %(levelname)s %(message)s",
     )
-    
+
+    cw_log_group = os.environ.get("CLOUDWATCH_LOG_GROUP")
+    cw_log_stream = os.environ.get("CLOUDWATCH_LOG_STREAM")
+    if cw_log_group and cw_log_stream:
+        region_name = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+        try:
+            cw_handler = CloudWatchLogsHandler(
+                log_group=cw_log_group,
+                log_stream=cw_log_stream,
+                region_name=region_name,
+            )
+        except ClientError as exc:
+            raise SystemExit(f"Unable to configure CloudWatch logging: {exc}") from exc
+
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        cw_handler.setLevel(level)
+        cw_handler.setFormatter(formatter)
+        logging.getLogger().addHandler(cw_handler)
+
     # For level 0, just touch the file without adding any content
     if log_level == 0:
         # Reset handlers to avoid any logging


### PR DESCRIPTION
## Summary
- add a boto3-powered CloudWatch handler that can be enabled with CLOUDWATCH_LOG_GROUP and CLOUDWATCH_LOG_STREAM
- preserve existing file logging defaults and fail fast when CloudWatch configuration cannot be established

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cc82f248832cac5a48ea6ae32504)