### PR TITLE
Add cross-platform logging smoke test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,10 @@ A CLI tool to evaluate and score Hugging Face models, datasets, and codebases fo
 - Typer, Pydantic, HuggingFace Hub, GitPython, pytest, black, isort, flake8, mypy
 - See `Makefile` for common tasks
 
+### Structured logging smoke test
+
+To validate the JSON logging pipeline, follow the cross-platform steps in
+[`docs/logging_smoke_test.md`](docs/logging_smoke_test.md).
+
 
 

--- a/docs/git_branch_instructions.md
+++ b/docs/git_branch_instructions.md
@@ -1,0 +1,41 @@
+# Working with Feature Branches
+
+To create a local copy of a remote branch (for example, `miller`) so you can review
+or build on the latest changes, follow the steps below from inside the repository
+root:
+
+1. **Fetch the latest branches and commits from the remote:**
+   ```bash
+   git fetch origin
+   ```
+
+2. **Create a local branch that tracks the remote branch:**
+   ```bash
+   git checkout -b miller origin/miller
+   ```
+
+   The `-b` flag creates a new local branch, and specifying `origin/miller`
+   ensures the branch starts from the same commit as the remote reference.
+
+3. **Verify the branch is tracking the remote counterpart (optional):**
+   ```bash
+   git status -sb
+   ```
+   The output should resemble `## miller...origin/miller`, confirming that the
+   local branch is set to push and pull against `origin/miller`.
+
+4. **Pull subsequent updates from the remote branch:**
+   ```bash
+   git pull
+   ```
+   When you are on the `miller` branch, this keeps your local copy in sync.
+
+5. **Push any local commits back to the remote branch:**
+   ```bash
+   git push
+   ```
+   Git will automatically use the tracking relationship to push changes to
+   `origin/miller`.
+
+These steps provide a local working copy of the remote branch and keep it aligned
+with the source of truth.

--- a/docs/logging_smoke_test.md
+++ b/docs/logging_smoke_test.md
@@ -1,0 +1,58 @@
+# Structured logging smoke test
+
+The `scripts/logging_smoke_test.py` helper makes it easy to validate the JSON
+logging pipeline without worrying about shell-specific syntax. It works on both
+POSIX shells and the Windows `cmd.exe` prompt.
+
+## 1. Choose a log destination and level
+
+Decide where you want the log file to be written and which verbosity to use.
+
+* `LOG_LEVEL=0` — create the file and suppress log output.
+* `LOG_LEVEL=1` — emit INFO logs.
+* `LOG_LEVEL=2` — emit DEBUG logs.
+
+Set the values for your shell:
+
+### Windows `cmd.exe`
+```bat
+set LOG_FILE=%TEMP%\acme.log
+set LOG_LEVEL=2
+```
+
+### PowerShell
+```powershell
+$env:LOG_FILE = "$env:TEMP/acme.log"
+$env:LOG_LEVEL = "2"
+```
+
+### POSIX shells (`bash`, `zsh`, etc.)
+```bash
+export LOG_FILE=/tmp/acme.log
+export LOG_LEVEL=2
+```
+
+## 2. Run the smoke-test script
+
+From the repository root, execute:
+
+```bash
+python scripts/logging_smoke_test.py --user jane@example.com --endpoint /artifact/model-42 --model-id model-42 --latency 0.123
+```
+
+On Windows `cmd.exe` the command is identical.
+
+You can customise the message or any of the optional fields. For example:
+
+```bash
+python scripts/logging_smoke_test.py "Registry warmup" --status 202 --request-id warmup-1
+```
+
+## 3. Inspect the output
+
+Open the log file you configured (for example `%TEMP%\acme.log` or `/tmp/acme.log`).
+Each line is a JSON object containing the timestamp, message, level, and the
+Lambda metadata supplied through `log_event`.
+
+If you have `CLOUDWATCH_LOG_GROUP`/`CLOUDWATCH_LOG_STREAM` configured, the same
+entry is also sent to CloudWatch.

--- a/lambda_handlers/create_artifact.py
+++ b/lambda_handlers/create_artifact.py
@@ -5,7 +5,7 @@ Registers a new artifact and evaluates it.
 """
 
 import json
-import logging
+from time import perf_counter
 from typing import Dict, Any
 
 from lambda_handlers.utils import (
@@ -14,11 +14,9 @@ from lambda_handlers.utils import (
     generate_artifact_id,
     artifact_exists_in_s3,
     save_artifact_to_s3,
-    MIN_NET_SCORE_THRESHOLD
+    MIN_NET_SCORE_THRESHOLD,
+    log_event,
 )
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict:
@@ -32,16 +30,43 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
     - event['body'] - JSON string with {"url": "..."}
     - event['headers']['X-Authorization'] - Auth token (optional)
     """
+    start_time = perf_counter()
+    artifact_id = None
+
     try:
-        logger.info(f"create_artifact invoked: {json.dumps(event)}")
+        log_event(
+            "info",
+            f"create_artifact invoked: {json.dumps(event)}",
+            event=event,
+            context=context,
+        )
 
         # Handle OPTIONS preflight
         if event.get('httpMethod') == 'OPTIONS':
+            latency = perf_counter() - start_time
+            log_event(
+                "info",
+                "Handled OPTIONS preflight for create_artifact",
+                event=event,
+                context=context,
+                latency=latency,
+                status=200,
+            )
             return create_response(200, {})
 
         # Parse path parameter
         artifact_type = event.get('pathParameters', {}).get('artifact_type')
         if not artifact_type or artifact_type not in ['model', 'dataset', 'code']:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Invalid artifact_type supplied",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="invalid_artifact_type",
+            )
             return create_response(400, {
                 "error": "Invalid artifact_type. Must be model, dataset, or code."
             })
@@ -51,12 +76,32 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
         try:
             body = json.loads(body_str) if isinstance(body_str, str) else body_str
         except json.JSONDecodeError:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Invalid JSON payload for create_artifact",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="invalid_payload",
+            )
             return create_response(400, {
                 "error": "There is missing field(s) in the artifact_data or it is formed improperly (must include a single url)."
             })
 
         url = body.get('url', '').strip()
         if not url:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Missing URL in create_artifact payload",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="missing_url",
+            )
             return create_response(400, {
                 "error": "There is missing field(s) in the artifact_data or it is formed improperly (must include a single url)."
             })
@@ -66,22 +111,55 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
 
         # Check if already exists in S3
         if artifact_exists_in_s3(artifact_id):
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                f"Artifact already exists: {artifact_id}",
+                event=event,
+                context=context,
+                model_id=artifact_id,
+                latency=latency,
+                status=409,
+                error_code="artifact_exists",
+            )
             return create_response(409, {"error": "Artifact exists already."})
 
         # Evaluate the artifact (only models supported for now)
         if artifact_type == 'model':
             try:
-                rating = evaluate_model(url)
+                rating = evaluate_model(url, event=event, context=context)
 
                 # Check if rating is acceptable
                 if rating.get("net_score", 0) < MIN_NET_SCORE_THRESHOLD:
+                    latency = perf_counter() - start_time
+                    log_event(
+                        "warning",
+                        "Artifact net_score below threshold",
+                        event=event,
+                        context=context,
+                        model_id=artifact_id,
+                        latency=latency,
+                        status=424,
+                        error_code="rating_below_threshold",
+                    )
                     return create_response(424, {
                         "error": f"Artifact is not registered due to the disqualified rating (net_score={rating.get('net_score', 0):.2f} < {MIN_NET_SCORE_THRESHOLD})."
                     })
 
                 name = rating.get("name", "unknown")
             except Exception as e:
-                logger.error(f"Error evaluating artifact: {e}", exc_info=True)
+                latency = perf_counter() - start_time
+                log_event(
+                    "error",
+                    f"Error evaluating artifact: {e}",
+                    event=event,
+                    context=context,
+                    model_id=artifact_id,
+                    latency=latency,
+                    status=500,
+                    error_code="model_evaluation_failed",
+                    exc_info=True,
+                )
                 return create_response(500, {
                     "error": f"Error evaluating artifact: {str(e)}"
                 })
@@ -107,7 +185,16 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
         }
         save_artifact_to_s3(artifact_id, artifact_data)
 
-        logger.info(f"Registered artifact {artifact_id}: {name}")
+        latency = perf_counter() - start_time
+        log_event(
+            "info",
+            f"Registered artifact {artifact_id}: {name}",
+            event=event,
+            context=context,
+            model_id=artifact_id,
+            latency=latency,
+            status=201,
+        )
 
         # Return artifact envelope
         return create_response(201, {
@@ -116,5 +203,16 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
         })
 
     except Exception as e:
-        logger.error(f"Unexpected error in create_artifact: {e}", exc_info=True)
+        latency = perf_counter() - start_time
+        log_event(
+            "error",
+            f"Unexpected error in create_artifact: {e}",
+            event=event,
+            context=context,
+            model_id=artifact_id,
+            latency=latency,
+            status=500,
+            error_code="unexpected_error",
+            exc_info=True,
+        )
         return create_response(500, {"error": f"Internal server error: {str(e)}"})

--- a/lambda_handlers/get_artifact_by_id.py
+++ b/lambda_handlers/get_artifact_by_id.py
@@ -1,71 +1,142 @@
-"""
-Lambda handler for GET /artifact/{artifact_id}
-
-Returns the full artifact (metadata + url + rating) for the given ID.
-"""
+"""Lambda handler for GET /artifact/{artifact_type}/{id}."""
 
 import json
-import logging
+from time import perf_counter
 from typing import Any, Dict
 
 from lambda_handlers.utils import (
     create_response,
     list_all_artifacts_from_s3,
+    log_event,
 )
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """
-    Lambda handler for GET /artifacts/{artifact_type}/{id}
+    """Retrieve a single artifact by ID."""
 
-    API Gateway Event Structure:
-    - event['pathParameters']['artifact_type'] - Type of artifact (model/dataset/code)
-    - event['pathParameters']['id'] - ID of the artifact to fetch
-    - event['headers']['X-Authorization'] - Auth token (optional)
-    """
+    start_time = perf_counter()
+    artifact_id = None
+
     try:
-        logger.info(f"get_artifact_by_id invoked: {json.dumps(event)}")
+        log_event(
+            "info",
+            f"get_artifact_by_id invoked: {json.dumps(event)}",
+            event=event,
+            context=context,
+        )
 
-        # Handle OPTIONS preflight
         if event.get("httpMethod") == "OPTIONS":
+            latency = perf_counter() - start_time
+            log_event(
+                "info",
+                "Handled OPTIONS preflight for get_artifact_by_id",
+                event=event,
+                context=context,
+                latency=latency,
+                status=200,
+            )
             return create_response(200, {})
 
-        # Parse path parameters
         path_params = event.get("pathParameters", {})
         artifact_type = path_params.get("artifact_type")
         artifact_id = path_params.get("id")
 
-        if not artifact_type or artifact_type not in ['model', 'dataset', 'code']:
-            return create_response(400, {
-                "error": "There is missing field(s) in the artifact_type or it is formed improperly, or is invalid."
-            })
+        if not artifact_type or artifact_type not in ["model", "dataset", "code"]:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Invalid artifact_type supplied to get_artifact_by_id",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="invalid_artifact_type",
+            )
+            return create_response(
+                400,
+                {
+                    "error": "There is missing field(s) in the artifact_type or it is formed improperly, or is invalid."
+                },
+            )
 
         if not artifact_id:
-            return create_response(400, {
-                "error": "There is missing field(s) in the artifact_id or it is formed improperly, or is invalid."
-            })
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Missing artifact_id in get_artifact_by_id",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="missing_artifact_id",
+            )
+            return create_response(
+                400,
+                {
+                    "error": "There is missing field(s) in the artifact_id or it is formed improperly, or is invalid."
+                },
+            )
 
-        # Load all artifacts from S3 (registry-style)
         all_artifacts = list_all_artifacts_from_s3()
 
         artifact_data = all_artifacts.get(artifact_id)
         if not artifact_data:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Artifact not found when fetching by id",
+                event=event,
+                context=context,
+                model_id=artifact_id,
+                latency=latency,
+                status=404,
+                error_code="artifact_not_found",
+            )
             return create_response(404, {"error": "Artifact does not exist."})
 
-        # Verify artifact type matches
         stored_type = artifact_data.get("metadata", {}).get("type") or artifact_data.get("type")
         if stored_type != artifact_type:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Artifact type mismatch for requested id",
+                event=event,
+                context=context,
+                model_id=artifact_id,
+                latency=latency,
+                status=404,
+                error_code="artifact_type_mismatch",
+            )
             return create_response(404, {"error": "Artifact does not exist."})
 
-        # Return artifact in OpenAPI spec format (metadata + data)
         response_data = {
             "metadata": artifact_data.get("metadata", {}),
-            "data": {"url": artifact_data.get("url", "")}
+            "data": {"url": artifact_data.get("url", "")},
         }
+
+        latency = perf_counter() - start_time
+        log_event(
+            "info",
+            f"Returned artifact {artifact_id}",
+            event=event,
+            context=context,
+            model_id=artifact_id,
+            latency=latency,
+            status=200,
+        )
         return create_response(200, response_data)
 
-    except Exception as exc:
-        logger.error("Unexpected error in get_artifact_by_id", exc_info=True)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        latency = perf_counter() - start_time
+        log_event(
+            "error",
+            f"Unexpected error in get_artifact_by_id: {exc}",
+            event=event,
+            context=context,
+            model_id=artifact_id,
+            latency=latency,
+            status=500,
+            error_code="unexpected_error",
+            exc_info=True,
+        )
         return create_response(500, {"error": f"Internal server error: {str(exc)}"})

--- a/lambda_handlers/get_artifact_by_name.py
+++ b/lambda_handlers/get_artifact_by_name.py
@@ -5,16 +5,14 @@ Returns metadata for all artifacts matching the provided name.
 """
 
 import json
-import logging
+from time import perf_counter
 from typing import Dict, Any
 
 from lambda_handlers.utils import (
     create_response,
-    list_all_artifacts_from_s3
+    list_all_artifacts_from_s3,
+    log_event,
 )
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict:
@@ -27,16 +25,44 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
     - event['pathParameters']['name'] - Artifact name to search for
     - event['headers']['X-Authorization'] - Auth token (optional)
     """
+    start_time = perf_counter()
+    artifact_name = None
+
     try:
-        logger.info(f"get_artifact_by_name invoked: {json.dumps(event)}")
+        log_event(
+            "info",
+            f"get_artifact_by_name invoked: {json.dumps(event)}",
+            event=event,
+            context=context,
+        )
 
         # Handle OPTIONS preflight
         if event.get('httpMethod') == 'OPTIONS':
+            latency = perf_counter() - start_time
+            log_event(
+                "info",
+                "Handled OPTIONS preflight for get_artifact_by_name",
+                event=event,
+                context=context,
+                latency=latency,
+                status=200,
+            )
             return create_response(200, {})
 
         # Parse path parameter
         name = event.get('pathParameters', {}).get('name')
+        artifact_name = name
         if not name:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Missing artifact name in get_artifact_by_name",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="missing_artifact_name",
+            )
             return create_response(400, {
                 "error": "There is missing field(s) in the artifact_name or it is formed improperly, or is invalid."
             })
@@ -54,11 +80,42 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
 
         # Return 404 if no matches found
         if not matching_artifacts:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "No artifacts found matching requested name",
+                event=event,
+                context=context,
+                model_id=None,
+                latency=latency,
+                status=404,
+                error_code="artifact_not_found",
+            )
             return create_response(404, {"error": "No such artifact."})
 
-        logger.info(f"Found {len(matching_artifacts)} artifact(s) with name '{name}'")
+        latency = perf_counter() - start_time
+        log_event(
+            "info",
+            f"Found {len(matching_artifacts)} artifact(s) with name '{name}'",
+            event=event,
+            context=context,
+            model_id=None,
+            latency=latency,
+            status=200,
+        )
         return create_response(200, matching_artifacts)
 
     except Exception as e:
-        logger.error(f"Unexpected error in get_artifact_by_name: {e}", exc_info=True)
+        latency = perf_counter() - start_time
+        log_event(
+            "error",
+            f"Unexpected error in get_artifact_by_name: {e}",
+            event=event,
+            context=context,
+            model_id=artifact_name,
+            latency=latency,
+            status=500,
+            error_code="unexpected_error",
+            exc_info=True,
+        )
         return create_response(500, {"error": f"Internal server error: {str(e)}"})

--- a/lambda_handlers/rate_artifact.py
+++ b/lambda_handlers/rate_artifact.py
@@ -5,18 +5,16 @@ Returns the rating for a registered model artifact.
 """
 
 import json
-import logging
+from time import perf_counter
 from typing import Dict, Any
 
 from lambda_handlers.utils import (
     create_response,
     evaluate_model,
     load_artifact_from_s3,
-    save_artifact_to_s3
+    save_artifact_to_s3,
+    log_event,
 )
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict:
@@ -29,22 +27,60 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
     - event['pathParameters']['id'] - Artifact ID
     - event['headers']['X-Authorization'] - Auth token (optional)
     """
+    start_time = perf_counter()
+    artifact_id = None
+
     try:
-        logger.info(f"rate_artifact invoked: {json.dumps(event)}")
+        log_event(
+            "info",
+            f"rate_artifact invoked: {json.dumps(event)}",
+            event=event,
+            context=context,
+        )
 
         # Handle OPTIONS preflight
         if event.get('httpMethod') == 'OPTIONS':
+            latency = perf_counter() - start_time
+            log_event(
+                "info",
+                "Handled OPTIONS preflight for rate_artifact",
+                event=event,
+                context=context,
+                latency=latency,
+                status=200,
+            )
             return create_response(200, {})
 
         # Parse path parameter
         artifact_id = event.get('pathParameters', {}).get('id')
         if not artifact_id:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Missing artifact_id in rate_artifact",
+                event=event,
+                context=context,
+                latency=latency,
+                status=400,
+                error_code="missing_artifact_id",
+            )
             return create_response(400, {
                 "error": "There is missing field(s) in the artifact_id or it is formed improperly, or is invalid."
             })
 
         # Validate ID format
         if not artifact_id.replace("-", "").replace("_", "").isalnum():
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Invalid artifact_id format",
+                event=event,
+                context=context,
+                model_id=artifact_id,
+                latency=latency,
+                status=400,
+                error_code="invalid_artifact_id",
+            )
             return create_response(400, {
                 "error": "There is missing field(s) in the artifact_id or it is formed improperly, or is invalid."
             })
@@ -52,10 +88,32 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
         # Load artifact from S3
         artifact = load_artifact_from_s3(artifact_id)
         if not artifact:
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Artifact not found for rating",
+                event=event,
+                context=context,
+                model_id=artifact_id,
+                latency=latency,
+                status=404,
+                error_code="artifact_not_found",
+            )
             return create_response(404, {"error": "Artifact does not exist."})
 
         # Verify it's a model
         if artifact.get("type") != "model":
+            latency = perf_counter() - start_time
+            log_event(
+                "warning",
+                "Attempted to rate non-model artifact",
+                event=event,
+                context=context,
+                model_id=artifact_id,
+                latency=latency,
+                status=400,
+                error_code="invalid_artifact_type",
+            )
             return create_response(400, {
                 "error": f"Artifact {artifact_id} is not a model"
             })
@@ -65,19 +123,50 @@ def handler(event: Dict[str, Any], context: Any) -> Dict:
         if not rating:
             url = artifact.get("url")
             try:
-                rating = evaluate_model(url)
+                rating = evaluate_model(url, event=event, context=context)
                 # Update S3 with new rating
                 artifact["rating"] = rating
                 save_artifact_to_s3(artifact_id, artifact)
             except Exception as e:
-                logger.error(f"Error evaluating artifact {artifact_id}: {e}", exc_info=True)
+                latency = perf_counter() - start_time
+                log_event(
+                    "error",
+                    f"Error evaluating artifact {artifact_id}: {e}",
+                    event=event,
+                    context=context,
+                    model_id=artifact_id,
+                    latency=latency,
+                    status=500,
+                    error_code="model_evaluation_failed",
+                    exc_info=True,
+                )
                 return create_response(500, {
                     "error": "The artifact rating system encountered an error while computing at least one metric."
                 })
 
-        logger.info(f"Returning rating for artifact {artifact_id}")
+        latency = perf_counter() - start_time
+        log_event(
+            "info",
+            f"Returning rating for artifact {artifact_id}",
+            event=event,
+            context=context,
+            model_id=artifact_id,
+            latency=latency,
+            status=200,
+        )
         return create_response(200, rating)
 
     except Exception as e:
-        logger.error(f"Unexpected error in rate_artifact: {e}", exc_info=True)
+        latency = perf_counter() - start_time
+        log_event(
+            "error",
+            f"Unexpected error in rate_artifact: {e}",
+            event=event,
+            context=context,
+            model_id=artifact_id,
+            latency=latency,
+            status=500,
+            error_code="unexpected_error",
+            exc_info=True,
+        )
         return create_response(500, {"error": f"Internal server error: {str(e)}"})

--- a/lambda_handlers/reset_registry.py
+++ b/lambda_handlers/reset_registry.py
@@ -4,37 +4,79 @@ Resets the registry by deleting all persisted artifacts.
 """
 
 import json
-import logging
+from time import perf_counter
 from typing import Any, Dict
 
 from botocore.exceptions import ClientError
 
-from lambda_handlers.utils import create_response, delete_all_artifacts_from_s3
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+from lambda_handlers.utils import create_response, delete_all_artifacts_from_s3, log_event
 
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Handle DELETE /reset requests."""
 
+    start_time = perf_counter()
+
     try:
-        logger.info(f"reset_registry invoked: {json.dumps(event)}")
+        log_event(
+            "info",
+            f"reset_registry invoked: {json.dumps(event)}",
+            event=event,
+            context=context,
+        )
 
         if event.get("httpMethod") == "OPTIONS":
+            latency = perf_counter() - start_time
+            log_event(
+                "info",
+                "Handled OPTIONS preflight for reset_registry",
+                event=event,
+                context=context,
+                latency=latency,
+                status=200,
+            )
             return create_response(200, {})
 
         try:
             deleted = delete_all_artifacts_from_s3()
         except ClientError:
+            latency = perf_counter() - start_time
+            log_event(
+                "error",
+                "Failed to delete artifacts during registry reset",
+                event=event,
+                context=context,
+                latency=latency,
+                status=500,
+                error_code="reset_failed",
+            )
             return create_response(500, {"error": "Failed to reset registry storage."})
 
         body = {
             "status": "reset",
             "deleted_artifacts": deleted,
         }
+        latency = perf_counter() - start_time
+        log_event(
+            "info",
+            f"Registry reset completed, deleted {deleted} artifacts",
+            event=event,
+            context=context,
+            latency=latency,
+            status=200,
+        )
         return create_response(200, body)
     except Exception as exc:  # pragma: no cover - safety net for unexpected errors
-        logger.error("Unexpected error in reset_registry", exc_info=True)
+        latency = perf_counter() - start_time
+        log_event(
+            "error",
+            f"Unexpected error in reset_registry: {exc}",
+            event=event,
+            context=context,
+            latency=latency,
+            status=500,
+            error_code="unexpected_error",
+            exc_info=True,
+        )
         return create_response(500, {"error": f"Internal server error: {str(exc)}"})
 

--- a/scripts/logging_smoke_test.py
+++ b/scripts/logging_smoke_test.py
@@ -1,0 +1,106 @@
+"""Utility script to exercise structured logging configuration.
+
+This script invokes ``setup_logging`` and emits a sample JSON log entry via
+``lambda_handlers.utils.log_event``.  It is designed to work uniformly across
+Windows ``cmd.exe`` and POSIX shells, so users can quickly confirm the logging
+pipeline without worrying about shell-specific syntax.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from types import SimpleNamespace
+from typing import Optional
+
+from lambda_handlers import utils
+from src.logging_config import setup_logging
+
+
+def _build_event(user: Optional[str], endpoint: Optional[str], request_id: Optional[str]):
+    request_context = {}
+    if request_id:
+        request_context["requestId"] = request_id
+    http_context = {}
+    if endpoint:
+        http_context["path"] = endpoint
+    if http_context:
+        request_context["http"] = http_context
+    if user:
+        request_context.setdefault("identity", {})["user"] = user
+    if request_context:
+        return {"requestContext": request_context}
+    return {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emit a sample structured log entry")
+    parser.add_argument("message", nargs="?", default="Structured logging smoke test")
+    parser.add_argument("--log-file", dest="log_file", help="Target log file path")
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        type=int,
+        choices=[0, 1, 2],
+        help="Numeric log level matching LOG_LEVEL semantics",
+    )
+    parser.add_argument("--user", dest="user", help="Simulated caller identity")
+    parser.add_argument("--endpoint", dest="endpoint", help="Simulated endpoint path")
+    parser.add_argument(
+        "--request-id",
+        dest="request_id",
+        help="Request identifier placed into the event context",
+    )
+    parser.add_argument(
+        "--context-id",
+        dest="context_id",
+        help="aws_request_id used on the synthetic Lambda context",
+    )
+    parser.add_argument("--model-id", dest="model_id", help="Associated model identifier")
+    parser.add_argument(
+        "--latency",
+        dest="latency",
+        type=float,
+        help="Simulated latency value in seconds",
+    )
+    parser.add_argument(
+        "--status",
+        dest="status",
+        type=int,
+        default=200,
+        help="HTTP status code to embed in the log entry",
+    )
+    parser.add_argument("--error-code", dest="error_code", help="Optional error code")
+    parser.add_argument(
+        "--level",
+        dest="level",
+        default="info",
+        help="Logging level name (e.g. info, warning, error)",
+    )
+
+    args = parser.parse_args()
+
+    if args.log_file:
+        os.environ["LOG_FILE"] = args.log_file
+    if args.log_level is not None:
+        os.environ["LOG_LEVEL"] = str(args.log_level)
+
+    setup_logging()
+
+    event = _build_event(args.user, args.endpoint, args.request_id)
+    context_id = args.context_id or args.request_id
+    context = SimpleNamespace(aws_request_id=context_id) if context_id else None
+
+    utils.log_event(
+        args.level,
+        args.message,
+        event=event,
+        context=context,
+        model_id=args.model_id,
+        latency=args.latency,
+        status=args.status,
+        error_code=args.error_code,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable `scripts/logging_smoke_test.py` utility to emit structured log entries without shell-specific syntax
- document cross-platform steps for verifying logging in `docs/logging_smoke_test.md` and link the guide from the README

## Testing
- pytest tests/test_logging_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110d1ffb3c832c907754d31d311d4f)